### PR TITLE
feat: 점검 요청 플로우 구현

### DIFF
--- a/app/api/ananlysis.py
+++ b/app/api/ananlysis.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from app.services.review_analysis_service import analyze_review
+from app.core.logger import logger
+
+router = APIRouter(prefix="/analysis")
+
+
+class ReviewAnalysisRequest(BaseModel):
+    spaceId: int
+    presentationId: int
+    options: list[str]
+
+@router.post("/review")
+def review_analysis(req: ReviewAnalysisRequest):
+    result = analyze_review(
+        space_id=req.spaceId,
+        presentation_id=req.presentationId,
+        options=req.options
+    )
+    return {"result": result}
+

--- a/app/api/ananlysis.py
+++ b/app/api/ananlysis.py
@@ -18,5 +18,5 @@ def review_analysis(req: ReviewAnalysisRequest):
         presentation_id=req.presentationId,
         options=req.options
     )
-    return {"result": result}
+    return result
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from app.core.logger import setup_logger
 from app.api.presentation_api import router as presentation_router
 from app.api.thumbnails import router as thumbnails_router
+from app.api.ananlysis import router as analysis_router
 
 setup_logger()
 
@@ -9,3 +10,4 @@ app = FastAPI()
 
 # API 라우터 등록
 app.include_router(thumbnails_router)
+app.include_router(analysis_router)

--- a/app/services/review_analysis_service.py
+++ b/app/services/review_analysis_service.py
@@ -1,0 +1,19 @@
+import os
+import tempfile
+from app.core.logger import logger
+from app.utils.s3_utils import download_from_s3
+from app.utils.s3_key_builder import slide_image_key
+from app.services.review_rules import run_analysis_rules
+from app.utils.s3_utils import load_slide_images
+
+
+def analyze_review(space_id: int, presentation_id: int, options: list[str]):
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        # 1) 슬라이드 이미지 다운로드
+        imgs = load_slide_images(space_id, presentation_id, tmpdir)
+
+        # 2) 옵션 기반 분석 실행
+        analysis_result = run_analysis_rules(imgs, options)
+
+        return analysis_result

--- a/app/services/review_rules.py
+++ b/app/services/review_rules.py
@@ -1,7 +1,5 @@
 from app.core.logger import logger
 
-from app.core.logger import logger
-
 def run_analysis_rules(images: list[str], options: list[str]):
     """
     선택된 옵션들만 실행하는 메인 룰 엔진
@@ -10,30 +8,31 @@ def run_analysis_rules(images: list[str], options: list[str]):
 
     for idx, img_path in enumerate(images):
         issues = []
+        logger.info(f"[RULE ENGINE] Running checks for slide {idx}, path={img_path}")
 
         if "spelling_grammar" in options:
-            issues.extend(check_spelling_grammar(img_path))
+            issues.extend(check_spelling_grammar(img_path, idx))
 
         if "font_consistency" in options:
-            issues.extend(check_font_consistency(img_path))
+            issues.extend(check_font_consistency(img_path, idx))
 
         if "shape_image_alignment" in options:
-            issues.extend(check_shape_image_alignment(img_path))
+            issues.extend(check_shape_image_alignment(img_path, idx))
 
         if "layout_alignment" in options:
-            issues.extend(check_layout_alignment(img_path))
+            issues.extend(check_layout_alignment(img_path, idx))
 
         if "theme" in options:
-            issues.extend(check_theme(img_path))
+            issues.extend(check_theme(img_path, idx))
 
         if "readability" in options:
-            issues.extend(check_readability(img_path))
+            issues.extend(check_readability(img_path, idx))
 
         if "color_contrast" in options:
-            issues.extend(check_color_contrast(img_path))
+            issues.extend(check_color_contrast(img_path, idx))
 
         if "design_feedback" in options:
-            issues.extend(check_design_feedback(img_path))
+            issues.extend(check_design_feedback(img_path, idx))
 
         results.append({
             "slide": idx,
@@ -45,51 +44,63 @@ def run_analysis_rules(images: list[str], options: list[str]):
         "results": results
     }
 
-def check_spelling_grammar(img_path: str):
-    """
-    맞춤법/오타 점검 (OCR → LanguageTool 등 연동 예상)
-    """
-    # TODO: OCR + grammar check
-    return []
 
-def check_font_consistency(img_path: str):
-    """
-    폰트 크기/스타일 일관성 점검
-    """
-    return []
+# ---------------------------
+# MOCKUP ISSUE GENERATORS
+# ---------------------------
 
-def check_shape_image_alignment(img_path: str):
-    """
-    도형/이미지 정렬 체크
-    """
-    return []
+def check_spelling_grammar(img_path: str, idx: int):
+    return [{
+        "type": "spelling_grammar",
+        "message": f"[MOCK] Slide {idx}: 맞춤법/오타 검사 실행됨",
+        "debug": img_path
+    }]
 
-def check_layout_alignment(img_path: str):
-    """
-    전체 레이아웃 정렬, 대칭성 체크
-    """
-    return []
+def check_font_consistency(img_path: str, idx: int):
+    return [{
+        "type": "font_consistency",
+        "message": f"[MOCK] Slide {idx}: 폰트 일관성 검사 실행됨",
+        "debug": img_path
+    }]
 
-def check_theme(img_path: str):
-    """
-    PPT 테마 분석 (색상 팔레트, 스타일 통일성)
-    """
-    return []
+def check_shape_image_alignment(img_path: str, idx: int):
+    return [{
+        "type": "shape_image_alignment",
+        "message": f"[MOCK] Slide {idx}: 도형/이미지 정렬 검사 실행됨",
+        "debug": img_path
+    }]
 
-def check_readability(img_path: str):
-    """
-    텍스트 가독성 분석
-    """
-    return []
+def check_layout_alignment(img_path: str, idx: int):
+    return [{
+        "type": "layout_alignment",
+        "message": f"[MOCK] Slide {idx}: 레이아웃 정렬 검사 실행됨",
+        "debug": img_path
+    }]
 
-def check_color_contrast(img_path: str):
-    """
-    색상 대비 검사(WCAG 대비 기준 등)
-    """
-    return []
+def check_theme(img_path: str, idx: int):
+    return [{
+        "type": "theme",
+        "message": f"[MOCK] Slide {idx}: 테마 분석 실행됨",
+        "debug": img_path
+    }]
 
-def check_design_feedback(img_path: str):
-    """
-    종합적인 디자인 피드백 (AI 기반 확장 예정)
-    """
-    return []
+def check_readability(img_path: str, idx: int):
+    return [{
+        "type": "readability",
+        "message": f"[MOCK] Slide {idx}: 가독성 분석 실행됨",
+        "debug": img_path
+    }]
+
+def check_color_contrast(img_path: str, idx: int):
+    return [{
+        "type": "color_contrast",
+        "message": f"[MOCK] Slide {idx}: 색상 대비 분석 실행됨",
+        "debug": img_path
+    }]
+
+def check_design_feedback(img_path: str, idx: int):
+    return [{
+        "type": "design_feedback",
+        "message": f"[MOCK] Slide {idx}: AI 디자인 피드백 실행됨",
+        "debug": img_path
+    }]

--- a/app/services/review_rules.py
+++ b/app/services/review_rules.py
@@ -1,0 +1,95 @@
+from app.core.logger import logger
+
+from app.core.logger import logger
+
+def run_analysis_rules(images: list[str], options: list[str]):
+    """
+    선택된 옵션들만 실행하는 메인 룰 엔진
+    """
+    results = []
+
+    for idx, img_path in enumerate(images):
+        issues = []
+
+        if "spelling_grammar" in options:
+            issues.extend(check_spelling_grammar(img_path))
+
+        if "font_consistency" in options:
+            issues.extend(check_font_consistency(img_path))
+
+        if "shape_image_alignment" in options:
+            issues.extend(check_shape_image_alignment(img_path))
+
+        if "layout_alignment" in options:
+            issues.extend(check_layout_alignment(img_path))
+
+        if "theme" in options:
+            issues.extend(check_theme(img_path))
+
+        if "readability" in options:
+            issues.extend(check_readability(img_path))
+
+        if "color_contrast" in options:
+            issues.extend(check_color_contrast(img_path))
+
+        if "design_feedback" in options:
+            issues.extend(check_design_feedback(img_path))
+
+        results.append({
+            "slide": idx,
+            "issues": issues,
+        })
+
+    return {
+        "slideCount": len(images),
+        "results": results
+    }
+
+def check_spelling_grammar(img_path: str):
+    """
+    맞춤법/오타 점검 (OCR → LanguageTool 등 연동 예상)
+    """
+    # TODO: OCR + grammar check
+    return []
+
+def check_font_consistency(img_path: str):
+    """
+    폰트 크기/스타일 일관성 점검
+    """
+    return []
+
+def check_shape_image_alignment(img_path: str):
+    """
+    도형/이미지 정렬 체크
+    """
+    return []
+
+def check_layout_alignment(img_path: str):
+    """
+    전체 레이아웃 정렬, 대칭성 체크
+    """
+    return []
+
+def check_theme(img_path: str):
+    """
+    PPT 테마 분석 (색상 팔레트, 스타일 통일성)
+    """
+    return []
+
+def check_readability(img_path: str):
+    """
+    텍스트 가독성 분석
+    """
+    return []
+
+def check_color_contrast(img_path: str):
+    """
+    색상 대비 검사(WCAG 대비 기준 등)
+    """
+    return []
+
+def check_design_feedback(img_path: str):
+    """
+    종합적인 디자인 피드백 (AI 기반 확장 예정)
+    """
+    return []

--- a/app/utils/s3_utils.py
+++ b/app/utils/s3_utils.py
@@ -1,0 +1,112 @@
+import json
+import boto3
+import os
+from botocore.exceptions import ClientError
+from app.core.logger import logger
+
+s3 = boto3.client("s3")
+BUCKET = os.getenv("AWS_S3_BUCKET_NAME")
+
+def download_from_s3(s3_key: str, dst_path: str):
+    """
+    S3의 특정 키 파일을 로컬 경로로 다운로드
+    """
+    try:
+        s3.download_file(BUCKET, s3_key, dst_path)
+        logger.info(f"[S3] Downloaded: s3://{BUCKET}/{s3_key} → {dst_path}")
+        return dst_path
+    except ClientError as e:
+        logger.error(f"[S3] Download failed: {s3_key}  ({e})")
+        raise
+
+def upload_to_s3(src_path: str, s3_key: str):
+    """
+    로컬 파일을 S3의 지정된 Key에 업로드
+    """
+    try:
+        s3.upload_file(src_path, BUCKET, s3_key)
+        logger.info(f"[S3] Uploaded: {src_path} → s3://{BUCKET}/{s3_key}")
+        return f"s3://{BUCKET}/{s3_key}"
+    except ClientError as e:
+        logger.error(f"[S3] Upload failed: {src_path}  ({e})")
+        raise
+
+def upload_json_to_s3(data: dict | list, s3_key: str):
+    """
+    JSON 데이터를 S3 특정 위치에 업로드
+    """
+    try:
+        json_bytes = json.dumps(data).encode("utf-8")
+        s3.put_object(Bucket=BUCKET, Key=s3_key, Body=json_bytes, ContentType="application/json")
+        logger.info(f"[S3] JSON uploaded: s3://{BUCKET}/{s3_key}")
+        return f"s3://{BUCKET}/{s3_key}"
+    except ClientError as e:
+        logger.error(f"[S3] JSON upload failed: {e}")
+        raise
+
+def read_s3_json(s3_key: str):
+    """
+    S3에 저장된 JSON 파일 읽기
+    """
+    try:
+        obj = s3.get_object(Bucket=BUCKET, Key=s3_key)
+        data = json.loads(obj["Body"].read())
+        logger.info(f"[S3] JSON loaded: s3://{BUCKET}/{s3_key}")
+        return data
+    except ClientError as e:
+        logger.error(f"[S3] Read failed: {s3_key} ({e})")
+        raise
+
+def list_s3_files(prefix: str) -> list[str]:
+    """
+    특정 prefix 아래의 모든 S3키 리스트 얻기
+    """
+    try:
+        resp = s3.list_objects_v2(Bucket=BUCKET, Prefix=prefix)
+        if "Contents" not in resp:
+            return []
+
+        keys = [item["Key"] for item in resp["Contents"]]
+        logger.info(f"[S3] Files under {prefix}: {len(keys)} found")
+        return keys
+
+    except ClientError as e:
+        logger.error(f"[S3] List failed: {prefix} ({e})")
+        raise
+
+def load_slide_images(space_id: int, presentation_id: int, tmpdir: str) -> list[str]:
+    """
+    S3에 저장된 슬라이드 이미지(s3://.../slides/slide_X.png)를
+    모두 찾아 로컬 tmpdir로 다운로드하여 로컬 경로 리스트로 반환.
+    """
+
+    from app.utils.s3_key_builder import base_path, slide_image_key
+
+    # 1) 슬라이드 이미지 prefix 생성
+    slides_prefix = f"{base_path(space_id, presentation_id)}/slides/"
+
+    # 2) prefix 아래 파일 목록 받아오기
+    slide_keys = list_s3_files(slides_prefix)
+
+    if not slide_keys:
+        raise RuntimeError(
+            f"No slide images found in S3 folder: s3://{BUCKET}/{slides_prefix}"
+        )
+
+    # slide_n.png 순서대로 정렬
+    slide_keys = sorted(
+        slide_keys,
+        key=lambda key: int(key.split("slide_")[1].split(".")[0])
+    )
+
+    local_paths = []
+
+    # 3) 모든 slide_X.png 다운로드
+    for key in slide_keys:
+        filename = key.split("/")[-1]  # slide_1.png
+        local_path = os.path.join(tmpdir, filename)
+        download_from_s3(key, local_path)
+        local_paths.append(local_path)
+
+    logger.info(f"[S3] Loaded {len(local_paths)} slide images for analysis")
+    return local_paths


### PR DESCRIPTION
## 🚩 관련 이슈
프론트에서 선택 항목을 받아 점검 요청을 보내는 플로우 구현
피피티 점검은 시간이 오래 걸리므로 비동기 작업으로 구현했습니다

## 📢 작업 내용
- 분석요청 받는 `app/api/analysis.py` 와 main에 라우터 추가
- app/services/review_analysis_service: S3에서 피피티 정보 읽어서 점검 로직을 호출하고 결과를 반환
- app/services/review_rules: 선택된 옵션에 따라 점검 로직을 호출하고 결과를 모으는 역할

## 📸 스크린샷


## ⚙️ 기타사항
아직 실제 점검은 연결하지 않음. 따라서 백에 전달되는 응답은 구조가 확정되지 않음
