### PR TITLE
feat: 피드백 적용 구현&S3에 버전별 저장으로 수정

### DIFF
--- a/app/api/modify.py
+++ b/app/api/modify.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, HTTPException
+from app.models.modify_dto import ApplyFeedbackBatchPayload
+from app.services.modify_service import process_modify
+
+router = APIRouter()
+
+
+@router.post("/modify")
+async def modify(batch: ApplyFeedbackBatchPayload):
+    result = process_modify(batch)
+    return result

--- a/app/api/thumbnails.py
+++ b/app/api/thumbnails.py
@@ -1,21 +1,27 @@
+# app/api/thumbnails.py
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 import os
 import tempfile
+
 from app.core.logger import logger
 from app.core.config import settings
-from app.services.storage_service import get_s3_client
+from app.services.storage_service import get_s3_client, save_file
 from app.services.ppt_to_pdf import convert_ppt_to_pdf
 from app.services.pdf_to_images import convert_pdf_to_images
-from app.utils.s3_key_builder import original_ppt_key
+from app.utils.s3_key_builder import original_ppt_key, slide_image_key_for_version
 
 from pptx import Presentation
 from app.utils.ppt_utils import emu_to_px
 
 router = APIRouter()
+
+
 class ThumbnailRequest(BaseModel):
     spaceId: int
     presentationId: int
+
 
 @router.post("/presentations/{presentation_id}/thumbnails")
 async def convert_ppt(
@@ -31,10 +37,11 @@ async def convert_ppt(
         with tempfile.TemporaryDirectory() as tmpdir:
             ppt_local = os.path.join(tmpdir, "original.pptx")
 
+            # 1) S3에서 v0 PPTX 다운로드
             s3 = get_s3_client()
             s3.download_file(settings.AWS_S3_BUCKET_NAME, original_key, ppt_local)
 
-            # 🎯 슬라이드 크기 추출
+            # 2) 슬라이드 크기 추출
             prs = Presentation(ppt_local)
             slide_width_px = emu_to_px(prs.slide_width)
             slide_height_px = emu_to_px(prs.slide_height)
@@ -43,20 +50,27 @@ async def convert_ppt(
                 {
                     "index": idx,
                     "width": slide_width_px,
-                    "height": slide_height_px
+                    "height": slide_height_px,
                 }
                 for idx, _ in enumerate(prs.slides, start=0)
             ]
 
-            # 1) PPT → PDF
+            # 3) PPT → PDF
             pdf_path = convert_ppt_to_pdf(ppt_local, tmpdir)
 
-            # 2) PDF → 이미지 변환 & 업로드
-            thumbnail_keys = convert_pdf_to_images(pdf_path, space_id, pres_id)
+            # 4) PDF → 이미지 바이트 리스트
+            image_bytes_list = convert_pdf_to_images(pdf_path)
+
+            # 5) 이미지 S3 업로드 (항상 v0 기준 썸네일)
+            thumbnail_keys = []
+            for idx, img_bytes in enumerate(image_bytes_list):
+                key = slide_image_key_for_version(space_id, pres_id, 0, idx)
+                save_file(key, img_bytes)  # 내부에서 bucket 사용
+                thumbnail_keys.append(key)
 
             return {
                 "thumbnailKeys": thumbnail_keys,
-                "slides": slide_sizes
+                "slides": slide_sizes,
             }
 
     except Exception as e:

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from app.core.logger import setup_logger
 from app.api.thumbnails import router as thumbnails_router
 from app.api.ananlysis import router as analysis_router
+from app.api.modify import router as modify_router
 
 setup_logger()
 
@@ -10,3 +11,4 @@ app = FastAPI()
 # API 라우터 등록
 app.include_router(thumbnails_router)
 app.include_router(analysis_router)
+app.include_router(modify_router)

--- a/app/models/modify_dto.py
+++ b/app/models/modify_dto.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+
+class ApplyFeedbackPayload(BaseModel):
+    presentationId: int
+    slideIndex: int
+
+    type: str               # "font_consistency" 등
+    detailsJson: str        # raw JSON string
+
+    shapeId: Optional[int]
+    elementIndex: Optional[int]
+
+    bboxLeft: float
+    bboxTop: float
+    bboxWidth: float
+    bboxHeight: float
+
+
+class ApplyFeedbackBatchPayload(BaseModel):
+    spaceId: int
+    presentationId: int
+
+    baseVersion: int
+    targetVersion: int
+
+    items: List[ApplyFeedbackPayload]

--- a/app/services/modify_service.py
+++ b/app/services/modify_service.py
@@ -1,0 +1,225 @@
+# app/services/modify_service.py
+
+import json
+import os
+import tempfile
+
+from pptx import Presentation
+from pptx.util import Pt
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.utils.s3_utils import download_from_s3, upload_to_s3
+from app.services.storage_service import save_file
+from app.utils.s3_key_builder import (
+    pptx_key_for_version,
+    slide_image_key_for_version,
+)
+from app.services.ppt_to_pdf import convert_ppt_to_pdf
+from app.services.pdf_to_images import convert_pdf_to_images
+
+
+def process_modify(batch):
+    """
+    전체 수정 작업 메인 엔트리:
+    - baseVersion PPTX 불러오기
+    - payload.items의 피드백을 차례대로 적용
+    - targetVersion PPTX / 이미지 생성 및 업로드
+    - 최종 ModifyResult(dict) 반환
+    """
+    pres_id = batch.presentationId
+    space_id = batch.spaceId
+
+    base_v = batch.baseVersion
+    target_v = batch.targetVersion
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_ppt_path = os.path.join(tmpdir, "base.pptx")
+        target_ppt_path = os.path.join(tmpdir, "target.pptx")
+
+        # 1) baseVersion PPT 다운로드
+        download_from_s3(
+            pptx_key_for_version(space_id, pres_id, base_v),
+            base_ppt_path
+        )
+
+        prs = Presentation(base_ppt_path)
+
+        # 2) payload.items 반복 → 슬라이드별 수정
+        for item in batch.items:
+            apply_single_feedback(prs, item)
+
+        # 3) targetVersion PPT 저장
+        prs.save(target_ppt_path)
+
+        # 4) target PPT S3 Key
+        ppt_key = pptx_key_for_version(space_id, pres_id, target_v)
+
+        # 5) PPT 업로드
+        upload_to_s3(
+            src_path=target_ppt_path,
+            s3_key=ppt_key,
+        )
+
+        # 6) PPT → PDF
+        pdf_path = convert_ppt_to_pdf(target_ppt_path, tmpdir)
+
+        # 7) PDF → 이미지 바이트 리스트
+        image_bytes_list = convert_pdf_to_images(pdf_path)
+        slide_count = len(image_bytes_list)
+
+        # 8) 이미지 업로드
+        for idx, img_bytes in enumerate(image_bytes_list):
+            key = slide_image_key_for_version(space_id, pres_id, target_v, idx)
+            save_file(key, img_bytes)
+
+        # 9) slidePrefix
+        slide_prefix = f"spaces/{space_id}/presentations/{pres_id}/v{target_v}/slides/"
+
+        # 10) 결과 반환(JSON으로 직렬화됨)
+        return {
+            "slideCount": slide_count,
+            "pptS3Key": ppt_key,
+            "slidePrefix": slide_prefix
+        }
+
+
+def apply_single_feedback(prs, item):
+    slide = prs.slides[item.slideIndex]
+
+    # ----- detailsJson 파싱 -----
+    details_raw = item.detailsJson or "{}"
+    details = None
+
+    try:
+        # 1차 loads (escape 제거)
+        loaded = json.loads(details_raw)
+
+        # loaded가 문자열이면 → 2차 loads 필요
+        if isinstance(loaded, str):
+            details = json.loads(loaded)
+        else:
+            details = loaded
+
+    except Exception:
+        details = {}
+        logger.error(f"[MODIFY] Failed to parse detailsJson: {details_raw}")
+
+    logger.info(
+        f"[MODIFY] Apply type='{item.type}', slide={item.slideIndex}, shapeId={item.shapeId}, details={details}"
+    )
+
+    # ----- 타입 라우팅 -----
+    if item.type == "font_consistency":
+        apply_font_consistency(slide, item, details)
+
+    elif item.type == "align_center":
+        apply_align_center(slide, item)
+
+    elif item.type == "spelling_grammar":
+        apply_text_replacement(slide, item, details)
+
+    else:
+        logger.warning(f"[MODIFY] Unknown feedback type: {item.type}")
+
+
+# -----------------------------
+# 각 규칙 apply 함수
+# -----------------------------
+def apply_font_consistency(slide, item, details):
+    """
+    details 예시:
+    {
+        "currentSize": 30.19,
+        "recommendedSize": 74.0
+    }
+    """
+
+    if item.shapeId is None:
+        logger.warning("[font_consistency] shapeId is None → skip")
+        return
+
+    current_size = details.get("currentSize")
+    recommended = details.get("recommendedSize")
+
+    if not current_size or not recommended:
+        logger.warning(
+            f"[font_consistency] currentSize/recommendedSize missing for shapeId={item.shapeId}"
+        )
+        return
+
+    scale = recommended / current_size
+
+    logger.info(
+        f"[font_consistency] shapeId={item.shapeId}, "
+        f"currentSize={current_size}, recommendedSize={recommended}, scale={scale:.2f}"
+    )
+
+    updated = False
+
+    for shape in slide.shapes:
+        if getattr(shape, "shape_id", None) != item.shapeId:
+            continue
+        if not shape.has_text_frame:
+            continue
+
+        # --- 1) 폰트 크기 변경 ---
+        for paragraph in shape.text_frame.paragraphs:
+            for run in paragraph.runs:
+                if run.font:
+                    run.font.size = Pt(recommended)
+
+        # --- 2) 텍스트박스 높이 조정: top 유지 + 아래로 확대 ---
+        old_top = shape.top
+        old_height = shape.height
+
+        new_height = int(old_height * scale)
+
+        shape.top = old_top            # top 그대로
+        shape.height = new_height      # 아래 방향으로 커짐
+
+        logger.info(
+            f"[font_consistency] shapeId={item.shapeId} "
+            f"height {old_height} → {new_height}, top={shape.top}"
+        )
+
+        updated = True
+
+    if not updated:
+        logger.warning(f"[font_consistency] No shape updated for shapeId={item.shapeId}")
+
+
+def apply_align_center(slide, item):
+    if item.shapeId is None:
+        return
+
+    for shape in slide.shapes:
+        if getattr(shape, "shape_id", None) == item.shapeId:
+            shape.left = int(item.bboxLeft)
+            shape.top = int(item.bboxTop)
+
+
+def apply_text_replacement(slide, item):
+    """
+    detailsJson 예시:
+    {"before": "helo", "after": "hello"}
+    """
+    if item.shapeId is None:
+        return
+
+    before = item.details.get("before")
+    after = item.details.get("after")
+
+    if not before or after is None:
+        return
+
+    for shape in slide.shapes:
+        if not shape.has_text_frame:
+            continue
+        if getattr(shape, "shape_id", None) != item.shapeId:
+            continue
+
+        for paragraph in shape.text_frame.paragraphs:
+            for run in paragraph.runs:
+                if run.text:
+                    run.text = run.text.replace(before, after)

--- a/app/services/pdf_to_images.py
+++ b/app/services/pdf_to_images.py
@@ -1,25 +1,25 @@
+# app/services/pdf_to_images.py
+
 import fitz
-from app.services.storage_service import save_file
-from app.utils.s3_key_builder import slide_image_key
+from typing import List
 
-def convert_pdf_to_images(pdf_path: str, space_id: int, presentation_id: int) -> list:
+
+def convert_pdf_to_images(pdf_path: str, dpi: int = 150) -> List[bytes]:
+    """
+    PDF 파일을 슬라이드 순서대로 PNG 이미지 바이트 리스트로 변환한다.
+    - S3 업로드는 여기서 하지 않는다.
+    - 호출자가 version 정보에 맞게 S3 저장을 담당한다.
+    """
     doc = fitz.open(pdf_path)
-    results = []
+    images: List[bytes] = []
 
-    for idx in range(len(doc)):
-        page = doc.load_page(idx)
-        pix = page.get_pixmap(dpi=150)
+    try:
+        for page_index in range(len(doc)):
+            page = doc.load_page(page_index)
+            pix = page.get_pixmap(dpi=dpi)
+            img_bytes = pix.tobytes("png")
+            images.append(img_bytes)
+    finally:
+        doc.close()
 
-        img_bytes = pix.tobytes("png")
-
-        # S3 key 생성
-        key = slide_image_key(space_id, presentation_id, idx)
-
-        # 저장 (하지만 반환은 URL이 아니라 key)
-        save_file(key, img_bytes)
-
-        # ✔ key만 append한다
-        results.append(key)
-
-    doc.close()
-    return results
+    return images

--- a/app/utils/s3_key_builder.py
+++ b/app/utils/s3_key_builder.py
@@ -2,6 +2,7 @@
 
 BASE = "spaces"
 
+
 def base_path(space_id: int, presentation_id: int) -> str:
     """
     기본 경로: spaces/{spaceId}/presentations/{presentationId}
@@ -10,25 +11,58 @@ def base_path(space_id: int, presentation_id: int) -> str:
 
 
 # =========================
-# Original PPTX
+# Versioned PPTX
+# =========================
+
+def pptx_key_for_version(space_id: int, presentation_id: int, version: int) -> str:
+    """
+    버전별 PPTX 파일
+    예) spaces/{spaceId}/presentations/{presentationId}/v{version}/ppt/presentation.pptx
+    """
+    return f"{base_path(space_id, presentation_id)}/v{version}/ppt/presentation.pptx"
+
+
+# =========================
+# Versioned Slides (이미지)
+# =========================
+
+def slide_image_key_for_version(
+    space_id: int,
+    presentation_id: int,
+    version: int,
+    slide_idx: int,
+) -> str:
+    """
+    버전별 슬라이드 이미지
+    예) .../v{version}/slides/{slide_idx}.png
+    """
+    return f"{base_path(space_id, presentation_id)}/v{version}/slides/{slide_idx}.png"
+
+
+# =========================
+# 원본 PPT (v0 alias)
 # =========================
 
 def original_ppt_key(space_id: int, presentation_id: int) -> str:
     """
-    원본 PPTX 파일 (업로드된 파일 그대로)
+    업로드된 원본 PPTX는 v0 으로 간주한다.
+    기존 original/ 경로 대신 이 함수를 사용한다.
     """
-    return f"{base_path(space_id, presentation_id)}/original/presentation.pptx"
+    return pptx_key_for_version(space_id, presentation_id, 0)
 
 
 # =========================
-# Slides (이미지)
+# (레거시) 버전 없는 slide 이미지 키
 # =========================
 
 def slide_image_key(space_id: int, presentation_id: int, slide_idx: int) -> str:
     """
-    슬라이드 이미지: slide_1.png, slide_2.png ...
+    과거 코드 호환을 위한 래퍼.
+    버전 개념이 없던 시절의 slide 이미지 경로를 사용하던 코드가
+    있더라도 v0 기준으로 동작하도록 매핑한다.
+    (가능하면 slide_image_key_for_version(...) 으로 교체할 것)
     """
-    return f"{base_path(space_id, presentation_id)}/slides/slide_{slide_idx}.png"
+    return slide_image_key_for_version(space_id, presentation_id, 0, slide_idx)
 
 
 # =========================
@@ -39,6 +73,7 @@ def analysis_key(space_id: int, presentation_id: int, filename: str) -> str:
     """
     분석 결과 파일 (JSON 등)
     예: layout.json, text.json, style.json ...
+    version과는 독립적으로 관리한다고 가정.
     """
     return f"{base_path(space_id, presentation_id)}/analysis/{filename}"
 


### PR DESCRIPTION
## 🚩 관련 이슈
피드백 적용해서 피피티 수정하는 기능 구현

## 📢 작업 내용
- 수정용 API + DTO + 서비스 추가
- 피피티의 버전 단위 관리를 위해 S3 버킷 저장경로 수정

## 📸 스크린샷


## ⚙️ 기타사항
